### PR TITLE
Change the installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,7 @@ set_target_properties(khiopsdriver_file_gcs PROPERTIES SOVERSION ${PROJECT_VERSI
 
 target_compile_options(
   khiopsdriver_file_gcs
-  PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:-Wall;/wd4582;/wd4583;/wd4625;/wd4626;/wd4710;/wd4711;/wd4820;/wd4868>
+  PRIVATE $<$<CXX_COMPILER_ID:MSVC>:-Wall;/wd4582;/wd4583;/wd4625;/wd4626;/wd4710;/wd4711;/wd4820;/wd4868>
   PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wall;-Wextra;-pedantic>)
 
 option(BUILD_TESTS "Build test programs" OFF)
@@ -85,10 +84,9 @@ endif(BUILD_TESTS)
 
 add_subdirectory(test)
 
-include(GNUInstallDirs)
 install(
   TARGETS khiopsdriver_file_gcs
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIB}
+  LIBRARY DESTINATION lib
   ARCHIVE # lib on windows
   RUNTIME # dll on windows
 )


### PR DESCRIPTION
The cmake module GNUInstallDirs doesn't provide a valide library location. It is better and simpler to use "lib" for both UNIXes and windows